### PR TITLE
Use structs to bind http request inputs

### DIFF
--- a/internal/app/http/torrents.go
+++ b/internal/app/http/torrents.go
@@ -43,7 +43,6 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 
 	{
 		group.POST("/torrents/new/file", func(c *gin.Context) {
-
 			// Source
 			file, err := c.FormFile("file")
 			if err != nil {

--- a/internal/app/http/torrents.go
+++ b/internal/app/http/torrents.go
@@ -1,9 +1,9 @@
 package http
 
 import (
+	"log"
 	"net/http"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/asdine/storm"
@@ -14,10 +14,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 )
-
-type NewTorrentFromMagnet struct {
-	MagnetURL string `form:"magnet_url" json:"magnet_url" binding:"required"`
-}
 
 type Torrent struct {
 	app.TorrentMeta
@@ -46,6 +42,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	s := h.TorrentService
 
 	group.POST("/torrents/new/file", func(c *gin.Context) {
+
 		// Source
 		file, err := c.FormFile("file")
 		if err != nil {
@@ -82,9 +79,13 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	})
 
 	group.POST("/torrents/new/magnet", func(c *gin.Context) {
-		var json NewTorrentFromMagnet
+		type Input struct {
+			MagnetURL string `form:"magnet_url" json:"magnet_url" binding:"required"`
+		}
+
+		var input Input
 		// in this case proper binding will be automatically selected
-		if err := c.ShouldBindJSON(&json); err != nil {
+		if err := c.ShouldBindJSON(&input); err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"error": err.Error(),
 			})
@@ -92,7 +93,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 		}
 
 		meta := app.GetDefaultTorrentMeta()
-		t, err := s.AddFromMagnet(json.MagnetURL, meta)
+		t, err := s.AddFromMagnet(input.MagnetURL, meta)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"error": err.Error(),
@@ -127,8 +128,19 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	})
 
 	group.GET("/torrents/torrent/:infoHash", func(c *gin.Context) {
-		infoHashStr := c.Param("infoHash")
-		t, err := s.GetByInfoHashStr(infoHashStr)
+		type Input struct {
+			InfoHash string `uri:"infoHash" binding:"required"`
+		}
+		var input Input
+
+		if err := c.ShouldBindUri(&input); err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		t, err := s.GetByInfoHashStr(input.InfoHash)
 		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
 				"error": err.Error(),
@@ -150,25 +162,28 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	})
 
 	group.GET("/torrents/torrent/:infoHash/stream/:file", func(c *gin.Context) {
-		hashStr := c.Param("infoHash")
-		fileIndexStr := c.Param("file")
+		type Input struct {
+			InfoHash  string `uri:"infoHash" binding:"required"`
+			FileIndex int    `uri:"file"`
+		}
+		var input Input
 
-		fileIndex, err := strconv.ParseInt(fileIndexStr, 10, 32)
+		if err := c.ShouldBindUri(&input); err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		t, err := s.GetByInfoHashStr(input.InfoHash)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),
 			})
 			return
 		}
-		t, err := s.GetByInfoHashStr(hashStr)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": err.Error(),
-			})
-			return
-		}
 
-		readseeker, err := s.GetReadSeekerForFileInTorrent(t, int(fileIndex))
+		readseeker, err := s.GetReadSeekerForFileInTorrent(t, input.FileIndex)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),
@@ -180,20 +195,24 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	})
 
 	group.GET("/torrents/find_for_movie", func(c *gin.Context) {
-		imdbID := c.Query("imdb_id")
-		title := c.Query("title")
-		year := c.Query("year")
-		minQualityStr := c.Query("min_quality")
-		minQuality, err := strconv.ParseInt(minQualityStr, 10, 32)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
+		type Input struct {
+			ImdbID     string `form:"imdb_id" binding:"required"`
+			Title      string `form:"title" binding:"required"`
+			Year       string `form:"year" binding:"required"`
+			MinQuality int    `form:"min_quality"`
+		}
+		var input Input
+
+		if err := c.ShouldBind(&input); err != nil {
+			log.Println("Error binding json: ", err)
+			c.JSON(http.StatusOK, gin.H{
 				"error": err.Error(),
 			})
 			return
 		}
 
 		// TODO: Rename links, confusing
-		links, err := h.TorrentLinkService.GetLinksForMovie(imdbID)
+		links, err := h.TorrentLinkService.GetLinksForMovie(input.ImdbID)
 		if err != nil {
 			if err != storm.ErrNotFound {
 				c.JSON(http.StatusInternalServerError, gin.H{
@@ -211,7 +230,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 			return
 		}
 
-		releases, err := h.ReleaseService.QueryMovie(imdbID, title, year, int(minQuality))
+		releases, err := h.ReleaseService.QueryMovie(input.ImdbID, input.Title, input.Year, input.MinQuality)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),
@@ -219,7 +238,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 			return
 		}
 
-		t, fileIndex, err := h.TorrentService.AddBestTorrentFromReleases(releases, h.Qualities[minQuality])
+		t, fileIndex, err := h.TorrentService.AddBestTorrentFromReleases(releases, h.Qualities[input.MinQuality])
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),
@@ -233,7 +252,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 			return
 		}
 
-		link, err := h.TorrentLinkService.LinkTorrentToMovie(imdbID, t, fileIndex)
+		link, err := h.TorrentLinkService.LinkTorrentToMovie(input.ImdbID, t, fileIndex)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{
 				"error": err.Error(),

--- a/internal/app/http/torrents.go
+++ b/internal/app/http/torrents.go
@@ -45,207 +45,205 @@ func newTorrentResponseFromInterfaceAndMetadata(tIn torrent.Torrent, meta app.To
 func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 	s := h.TorrentService
 
-	{
-		group.POST("/torrents/new/file", func(c *gin.Context) {
-			// Source
-			file, err := c.FormFile("file")
-			if err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			filename := filepath.Join(h.TorrentFilesPath, file.Filename)
-			if err := c.SaveUploadedFile(file, filename); err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			meta := app.GetDefaultTorrentMeta()
-			t, err := s.AddFromFile(filename, meta)
-			if err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			// Remove old file now that we have one in our system
-			os.Remove(filename)
-
+	group.POST("/torrents/new/file", func(c *gin.Context) {
+		// Source
+		file, err := c.FormFile("file")
+		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
-				"error":   nil,
-				"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
+				"error": err.Error(),
 			})
-		})
+			return
+		}
 
-		group.POST("/torrents/new/magnet", func(c *gin.Context) {
-			var json NewTorrentFromMagnet
-			// in this case proper binding will be automatically selected
-			if err := c.ShouldBindJSON(&json); err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			meta := app.GetDefaultTorrentMeta()
-			t, err := s.AddFromMagnet(json.MagnetURL, meta)
-			if err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
+		filename := filepath.Join(h.TorrentFilesPath, file.Filename)
+		if err := c.SaveUploadedFile(file, filename); err != nil {
 			c.JSON(http.StatusOK, gin.H{
-				"error":   nil,
-				"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
+				"error": err.Error(),
 			})
-		})
+			return
+		}
 
-		group.GET("/torrents", func(c *gin.Context) {
-			torrents, err := s.Get()
-			torrentResponses := make([]Torrent, len(torrents))
-
-			for i, t := range torrents {
-				meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
-				if err != nil {
-					torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, app.TorrentMeta{})
-					continue
-				}
-
-				torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, meta)
-			}
-
+		meta := app.GetDefaultTorrentMeta()
+		t, err := s.AddFromFile(filename, meta)
+		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
-				"torrents": torrentResponses,
-				"error":    err,
+				"error": err.Error(),
 			})
+			return
+		}
+
+		// Remove old file now that we have one in our system
+		os.Remove(filename)
+
+		c.JSON(http.StatusOK, gin.H{
+			"error":   nil,
+			"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
 		})
+	})
 
-		group.GET("/torrents/torrent/:infoHash", func(c *gin.Context) {
-			infoHashStr := c.Param("infoHash")
-			t, err := s.GetByInfoHashStr(infoHashStr)
-			if err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
+	group.POST("/torrents/new/magnet", func(c *gin.Context) {
+		var json NewTorrentFromMagnet
+		// in this case proper binding will be automatically selected
+		if err := c.ShouldBindJSON(&json); err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
 
+		meta := app.GetDefaultTorrentMeta()
+		t, err := s.AddFromMagnet(json.MagnetURL, meta)
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"error":   nil,
+			"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
+		})
+	})
+
+	group.GET("/torrents", func(c *gin.Context) {
+		torrents, err := s.Get()
+		torrentResponses := make([]Torrent, len(torrents))
+
+		for i, t := range torrents {
 			meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
 			if err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
+				torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, app.TorrentMeta{})
+				continue
 			}
 
+			torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, meta)
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"torrents": torrentResponses,
+			"error":    err,
+		})
+	})
+
+	group.GET("/torrents/torrent/:infoHash", func(c *gin.Context) {
+		infoHashStr := c.Param("infoHash")
+		t, err := s.GetByInfoHashStr(infoHashStr)
+		if err != nil {
 			c.JSON(http.StatusOK, gin.H{
-				"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
-				"error":   err.Error(),
+				"error": err.Error(),
 			})
+			return
+		}
+
+		meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"torrent": newTorrentResponseFromInterfaceAndMetadata(t, meta),
+			"error":   err.Error(),
 		})
+	})
 
-		group.GET("/torrents/torrent/:infoHash/stream/:file", func(c *gin.Context) {
-			hashStr := c.Param("infoHash")
-			fileIndexStr := c.Param("file")
+	group.GET("/torrents/torrent/:infoHash/stream/:file", func(c *gin.Context) {
+		hashStr := c.Param("infoHash")
+		fileIndexStr := c.Param("file")
 
-			fileIndex, err := strconv.ParseInt(fileIndexStr, 10, 32)
-			if err != nil {
+		fileIndex, err := strconv.ParseInt(fileIndexStr, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		t, err := s.GetByInfoHashStr(hashStr)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		readseeker, err := s.GetReadSeekerForFileInTorrent(t, int(fileIndex))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		http.ServeContent(c.Writer, c.Request, t.Name(), time.Time{}, readseeker)
+	})
+
+	group.GET("/torrents/find_for_movie", func(c *gin.Context) {
+		imdbID := c.Query("imdb_id")
+		title := c.Query("title")
+		year := c.Query("year")
+		minQualityStr := c.Query("min_quality")
+		minQuality, err := strconv.ParseInt(minQualityStr, 10, 32)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		// TODO: Rename links, confusing
+		links, err := h.TorrentLinkService.GetLinksForMovie(imdbID)
+		if err != nil {
+			if err != storm.ErrNotFound {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error": err.Error(),
 				})
 				return
 			}
-			t, err := s.GetByInfoHashStr(hashStr)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			readseeker, err := s.GetReadSeekerForFileInTorrent(t, int(fileIndex))
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			http.ServeContent(c.Writer, c.Request, t.Name(), time.Time{}, readseeker)
-		})
-
-		group.GET("/torrents/find_for_movie", func(c *gin.Context) {
-			imdbID := c.Query("imdb_id")
-			title := c.Query("title")
-			year := c.Query("year")
-			minQualityStr := c.Query("min_quality")
-			minQuality, err := strconv.ParseInt(minQualityStr, 10, 32)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			// TODO: Rename links, confusing
-			links, err := h.TorrentLinkService.GetLinksForMovie(imdbID)
-			if err != nil {
-				if err != storm.ErrNotFound {
-					c.JSON(http.StatusInternalServerError, gin.H{
-						"error": err.Error(),
-					})
-					return
-				}
-			}
-			// Return the torrent if one is already linked to this movie
-			if len(links) > 0 {
-				c.JSON(http.StatusOK, gin.H{
-					"error":       nil,
-					"torrentLink": links[0],
-				})
-				return
-			}
-
-			releases, err := h.ReleaseService.QueryMovie(imdbID, title, year, int(minQuality))
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			t, fileIndex, err := h.TorrentService.AddBestTorrentFromReleases(releases, h.Qualities[minQuality])
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-			if t == nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			link, err := h.TorrentLinkService.LinkTorrentToMovie(imdbID, t, fileIndex)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
+		}
+		// Return the torrent if one is already linked to this movie
+		if len(links) > 0 {
 			c.JSON(http.StatusOK, gin.H{
 				"error":       nil,
-				"torrentLink": link,
+				"torrentLink": links[0],
 			})
+			return
+		}
+
+		releases, err := h.ReleaseService.QueryMovie(imdbID, title, year, int(minQuality))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		t, fileIndex, err := h.TorrentService.AddBestTorrentFromReleases(releases, h.Qualities[minQuality])
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+		if t == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		link, err := h.TorrentLinkService.LinkTorrentToMovie(imdbID, t, fileIndex)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"error":       nil,
+			"torrentLink": link,
 		})
-	}
+	})
 }

--- a/internal/app/http/transcoder.go
+++ b/internal/app/http/transcoder.go
@@ -15,101 +15,103 @@ import (
 func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 	torrents := rg.Group("/transcoder")
 
-	torrents.GET("/from_url", func(c *gin.Context) {
-		type Input struct {
-			URL        string `form:"url" binding:"required"`
-			Time       string `form:"time"`
-			Resolution string `form:"res" binding:"required"`
-			MaxBitrate string `form:"max_bitrate" binding:"required"`
-		}
-		var input Input
+	{
+		torrents.GET("/from_url", func(c *gin.Context) {
+			type Input struct {
+				URL        string `form:"url" binding:"required"`
+				Time       string `form:"time"`
+				Resolution string `form:"res" binding:"required"`
+				MaxBitrate string `form:"max_bitrate" binding:"required"`
+			}
+			var input Input
 
-		if err := c.ShouldBind(&input); err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"error": err.Error(),
-			})
-			return
-		}
-
-		// Format time arg
-		formattedTimeStr := formatTimeString(input.Time)
-
-		c.Writer.Header().Set("Transfer-Encoding", "chunked") // TODO: Is this necessary? not really sure what it does
-
-		cmdFF := h.Transcoder.NewTranscodeCommand(input.URL, formattedTimeStr, input.Resolution, input.MaxBitrate, 0, 0)
-		cmdFF.Stdout = c.Writer
-		cmdFF.Start()
-
-		// Start a goroutine to listen for the request being dropped and end transcode if needed
-		go func() {
-			<-c.Request.Context().Done()
-			cmdFF.Process.Kill()
-			println("Client Disconnected... Ending process.")
-		}()
-
-		// Async execute function
-		if err := cmdFF.Wait(); err != nil {
-			status := cmdFF.ProcessState.Sys().(syscall.WaitStatus)
-			exitStatus := status.ExitStatus()
-			if exitStatus != 0 {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error":   true,
-					"message": "Transcoding failed",
+			if err := c.ShouldBind(&input); err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
 				})
 				return
 			}
-		} else {
-			log.Println("Error encoding: ", err.Error())
-		}
-	})
 
-	torrents.GET("/from_url/metadata", func(c *gin.Context) {
-		type Input struct {
-			URL string `form:"url" binding:"required"`
-		}
-		var input Input
+			// Format time arg
+			formattedTimeStr := formatTimeString(input.Time)
 
-		if err := c.ShouldBind(&input); err != nil {
-			c.JSON(http.StatusOK, gin.H{
-				"error": err.Error(),
-			})
+			c.Writer.Header().Set("Transfer-Encoding", "chunked") // TODO: Is this necessary? not really sure what it does
+
+			cmdFF := h.Transcoder.NewTranscodeCommand(input.URL, formattedTimeStr, input.Resolution, input.MaxBitrate, 0, 0)
+			cmdFF.Stdout = c.Writer
+			cmdFF.Start()
+
+			// Start a goroutine to listen for the request being dropped and end transcode if needed
+			go func() {
+				<-c.Request.Context().Done()
+				cmdFF.Process.Kill()
+				println("Client Disconnected... Ending process.")
+			}()
+
+			// Async execute function
+			if err := cmdFF.Wait(); err != nil {
+				status := cmdFF.ProcessState.Sys().(syscall.WaitStatus)
+				exitStatus := status.ExitStatus()
+				if exitStatus != 0 {
+					c.JSON(http.StatusInternalServerError, gin.H{
+						"error":   true,
+						"message": "Transcoding failed",
+					})
+					return
+				}
+			} else {
+				log.Println("Error encoding: ", err.Error())
+			}
+		})
+
+		torrents.GET("/from_url/metadata", func(c *gin.Context) {
+			type Input struct {
+				URL string `form:"url" binding:"required"`
+			}
+			var input Input
+
+			if err := c.ShouldBind(&input); err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
+				})
+				return
+			}
+
+			out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input.URL).Output()
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error":   true,
+					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
+				})
+				return
+			}
+			durString := string(out)
+			durString = durString[:len(durString)-1]
+
+			dur, err := strconv.ParseFloat(durString, 32)
+			if err != nil {
+				log.Println(err)
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error":   true,
+					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
+				})
+				return
+			}
+
+			// TODO: get full metadata
+			metadata := Metadata{
+				Format: Format{
+					Duration: int(dur),
+				},
+			}
+
+			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+			c.Writer.Header().Set("Content-Type", "application/json; charset=UTF-8")
+			c.Writer.WriteHeader(http.StatusOK)
+			if err := json.NewEncoder(c.Writer).Encode(metadata); err != nil {
+				panic(err)
+			}
 			return
-		}
-
-		out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input.URL).Output()
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   true,
-				"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
-			})
-			return
-		}
-		durString := string(out)
-		durString = durString[:len(durString)-1]
-
-		dur, err := strconv.ParseFloat(durString, 32)
-		if err != nil {
-			log.Println(err)
-			c.JSON(http.StatusInternalServerError, gin.H{
-				"error":   true,
-				"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
-			})
-			return
-		}
-
-		// TODO: get full metadata
-		metadata := Metadata{
-			Format: Format{
-				Duration: int(dur),
-			},
-		}
-
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-		c.Writer.Header().Set("Content-Type", "application/json; charset=UTF-8")
-		c.Writer.WriteHeader(http.StatusOK)
-		if err := json.NewEncoder(c.Writer).Encode(metadata); err != nil {
-			panic(err)
-		}
-		return
-	})
+		})
+	}
 }

--- a/internal/app/http/transcoder.go
+++ b/internal/app/http/transcoder.go
@@ -14,7 +14,6 @@ import (
 
 func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 	torrents := rg.Group("/transcoder")
-
 	{
 		torrents.GET("/from_url", func(c *gin.Context) {
 			type Input struct {

--- a/internal/app/http/transcoder.go
+++ b/internal/app/http/transcoder.go
@@ -14,103 +14,102 @@ import (
 
 func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 	torrents := rg.Group("/transcoder")
-	{
-		torrents.GET("/from_url", func(c *gin.Context) {
-			type Input struct {
-				URL        string `form:"url" binding:"required"`
-				Time       string `form:"time"`
-				Resolution string `form:"res" binding:"required"`
-				MaxBitrate string `form:"max_bitrate" binding:"required"`
-			}
-			var input Input
 
-			if err := c.ShouldBind(&input); err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
+	torrents.GET("/from_url", func(c *gin.Context) {
+		type Input struct {
+			URL        string `form:"url" binding:"required"`
+			Time       string `form:"time"`
+			Resolution string `form:"res" binding:"required"`
+			MaxBitrate string `form:"max_bitrate" binding:"required"`
+		}
+		var input Input
 
-			// Format time arg
-			formattedTimeStr := formatTimeString(input.Time)
-
-			c.Writer.Header().Set("Transfer-Encoding", "chunked") // TODO: Is this necessary? not really sure what it does
-
-			cmdFF := h.Transcoder.NewTranscodeCommand(input.URL, formattedTimeStr, input.Resolution, input.MaxBitrate, 0, 0)
-			cmdFF.Stdout = c.Writer
-			cmdFF.Start()
-
-			// Start a goroutine to listen for the request being dropped and end transcode if needed
-			go func() {
-				<-c.Request.Context().Done()
-				cmdFF.Process.Kill()
-				println("Client Disconnected... Ending process.")
-			}()
-
-			// Async execute function
-			if err := cmdFF.Wait(); err != nil {
-				status := cmdFF.ProcessState.Sys().(syscall.WaitStatus)
-				exitStatus := status.ExitStatus()
-				if exitStatus != 0 {
-					c.JSON(http.StatusInternalServerError, gin.H{
-						"error":   true,
-						"message": "Transcoding failed",
-					})
-					return
-				}
-			} else {
-				log.Println("Error encoding: ", err.Error())
-			}
-		})
-
-		torrents.GET("/from_url/metadata", func(c *gin.Context) {
-			type Input struct {
-				URL string `form:"url" binding:"required"`
-			}
-			var input Input
-
-			if err := c.ShouldBind(&input); err != nil {
-				c.JSON(http.StatusOK, gin.H{
-					"error": err.Error(),
-				})
-				return
-			}
-
-			out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input.URL).Output()
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error":   true,
-					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
-				})
-				return
-			}
-			durString := string(out)
-			durString = durString[:len(durString)-1]
-
-			dur, err := strconv.ParseFloat(durString, 32)
-			if err != nil {
-				log.Println(err)
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error":   true,
-					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
-				})
-				return
-			}
-
-			// TODO: get full metadata
-			metadata := Metadata{
-				Format: Format{
-					Duration: int(dur),
-				},
-			}
-
-			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
-			c.Writer.Header().Set("Content-Type", "application/json; charset=UTF-8")
-			c.Writer.WriteHeader(http.StatusOK)
-			if err := json.NewEncoder(c.Writer).Encode(metadata); err != nil {
-				panic(err)
-			}
+		if err := c.ShouldBind(&input); err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
 			return
-		})
-	}
+		}
+
+		// Format time arg
+		formattedTimeStr := formatTimeString(input.Time)
+
+		c.Writer.Header().Set("Transfer-Encoding", "chunked") // TODO: Is this necessary? not really sure what it does
+
+		cmdFF := h.Transcoder.NewTranscodeCommand(input.URL, formattedTimeStr, input.Resolution, input.MaxBitrate, 0, 0)
+		cmdFF.Stdout = c.Writer
+		cmdFF.Start()
+
+		// Start a goroutine to listen for the request being dropped and end transcode if needed
+		go func() {
+			<-c.Request.Context().Done()
+			cmdFF.Process.Kill()
+			println("Client Disconnected... Ending process.")
+		}()
+
+		// Async execute function
+		if err := cmdFF.Wait(); err != nil {
+			status := cmdFF.ProcessState.Sys().(syscall.WaitStatus)
+			exitStatus := status.ExitStatus()
+			if exitStatus != 0 {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error":   true,
+					"message": "Transcoding failed",
+				})
+				return
+			}
+		} else {
+			log.Println("Error encoding: ", err.Error())
+		}
+	})
+
+	torrents.GET("/from_url/metadata", func(c *gin.Context) {
+		type Input struct {
+			URL string `form:"url" binding:"required"`
+		}
+		var input Input
+
+		if err := c.ShouldBind(&input); err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"error": err.Error(),
+			})
+			return
+		}
+
+		out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input.URL).Output()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":   true,
+				"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
+			})
+			return
+		}
+		durString := string(out)
+		durString = durString[:len(durString)-1]
+
+		dur, err := strconv.ParseFloat(durString, 32)
+		if err != nil {
+			log.Println(err)
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error":   true,
+				"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
+			})
+			return
+		}
+
+		// TODO: get full metadata
+		metadata := Metadata{
+			Format: Format{
+				Duration: int(dur),
+			},
+		}
+
+		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		c.Writer.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		c.Writer.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(c.Writer).Encode(metadata); err != nil {
+			panic(err)
+		}
+		return
+	})
 }

--- a/internal/app/http/transcoder.go
+++ b/internal/app/http/transcoder.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/diericx/iceetime/internal/app"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,17 +16,27 @@ func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 	torrents := rg.Group("/transcoder")
 	{
 		torrents.GET("/from_url", func(c *gin.Context) {
-			url := c.Query("url")
-			timeArg := c.Query("time")
-			resolution := c.DefaultQuery("res", app.DefaultResolution)
-			maxBitrate := c.DefaultQuery("max_bitrate", app.DefaultMaxBitrate)
+			type Input struct {
+				URL        string `form:"url" binding:"required"`
+				Time       string `form:"time"`
+				Resolution string `form:"res" binding:"required"`
+				MaxBitrate string `form:"max_bitrate" binding:"required"`
+			}
+			var input Input
+
+			if err := c.ShouldBind(&input); err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
+				})
+				return
+			}
 
 			// Format time arg
-			formattedTimeStr := formatTimeString(timeArg)
+			formattedTimeStr := formatTimeString(input.Time)
 
 			c.Writer.Header().Set("Transfer-Encoding", "chunked") // TODO: Is this necessary? not really sure what it does
 
-			cmdFF := h.Transcoder.NewTranscodeCommand(url, formattedTimeStr, resolution, maxBitrate, 0, 0)
+			cmdFF := h.Transcoder.NewTranscodeCommand(input.URL, formattedTimeStr, input.Resolution, input.MaxBitrate, 0, 0)
 			cmdFF.Stdout = c.Writer
 			cmdFF.Start()
 
@@ -53,13 +62,25 @@ func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 				log.Println("Error encoding: ", err.Error())
 			}
 		})
+
 		torrents.GET("/from_url/metadata", func(c *gin.Context) {
-			url := c.Query("url")
-			out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", url).Output()
+			type Input struct {
+				URL string `form:"url" binding:"required"`
+			}
+			var input Input
+
+			if err := c.ShouldBind(&input); err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
+				})
+				return
+			}
+
+			out, err := exec.Command("ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", input.URL).Output()
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error":   true,
-					"message": fmt.Sprintf("Error fetching metadata", err.Error()),
+					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
 				})
 				return
 			}
@@ -71,7 +92,7 @@ func (h *HTTPHandler) addTranscoderGroup(rg *gin.RouterGroup) {
 				log.Println(err)
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error":   true,
-					"message": fmt.Sprintf("Error fetching metadata", err.Error()),
+					"message": fmt.Sprintf("Error fetching metadata: %s", err.Error()),
 				})
 				return
 			}


### PR DESCRIPTION
## `http/transcoder` and `http/torrents`
- Added input structs for each call that get created inside the functions. The motivation behind this is that they are only relevant to that request and don't want to clutter the file too much.

resolves #23 