### PR TITLE
Use metainfo hash instead of string

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "bootstrap": "^4.5.2",
     "dotenv": "^8.2.0",
     "pretty-bytes": "^5.4.1",
+    "pretty-time": "^1.1.0",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0",
     "react-dom": "^16.13.1",

--- a/frontend/src/pages/torrents.js
+++ b/frontend/src/pages/torrents.js
@@ -65,6 +65,8 @@ export default class Torrents extends React.Component {
                   <th>Peers</th>
                   <th>Uploaded</th>
                   <th>Downloaded</th>
+                  <th>Download Speed</th>
+                  <th>Time Seeded While Complete</th>
                 </tr>
               </thead>
               <tbody>
@@ -86,6 +88,8 @@ export default class Torrents extends React.Component {
                       </td>
                       <td>{prettyBytes(torrent.bytesWrittenData)}</td>
                       <td>{prettyBytes(torrent.bytesReadData)}</td>
+                      <td>{prettyBytes(torrent.downloadSpeed)}/s</td>
+                      <td>{torrent.secondsSeedingWhileCompleted}</td>
                     </tr>
                   );
                 })}

--- a/frontend/src/pages/torrents.js
+++ b/frontend/src/pages/torrents.js
@@ -8,11 +8,13 @@ import ProgressBar from 'react-bootstrap/ProgressBar';
 import Spinner from 'react-bootstrap/Table';
 import './movie.css';
 import prettyBytes from 'pretty-bytes';
+
 import TorrentStream from '../components/TorrentStream';
 import { result } from 'underscore';
 import NewTorrent from '../components/Torrents/NewTorrent.js';
 import { TorrentsAPI } from '../lib/IceetimeAPI';
 
+var prettyTime = require('pretty-time');
 let backendURL = window._env_.BACKEND_URL;
 const REFRESH_RATE = 2000;
 
@@ -89,7 +91,12 @@ export default class Torrents extends React.Component {
                       <td>{prettyBytes(torrent.bytesWrittenData)}</td>
                       <td>{prettyBytes(torrent.bytesReadData)}</td>
                       <td>{prettyBytes(torrent.downloadSpeed)}/s</td>
-                      <td>{torrent.secondsSeedingWhileCompleted}</td>
+                      <td>
+                        {prettyTime(
+                          [torrent.secondsSeedingWhileCompleted, 0],
+                          's'
+                        )}
+                      </td>
                     </tr>
                   );
                 })}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8679,6 +8679,11 @@ pretty-format@^26.4.2:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+pretty-time@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pretty-time/-/pretty-time-1.1.0.tgz#ffb7429afabb8535c346a34e41873adf3d74dd0e"
+  integrity sha512-28iF6xPQrP8Oa6uxE6a1biz+lWeTOAPKggvjB8HAs6nVMKZwf5bG++632Dx614hIWgUPkgivRfG+a8uAXGTIbA==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -44,7 +44,7 @@ type BasicAuth struct {
 type TorrentMeta struct {
 	ID int `storm:"id,increment"`
 	// Would like storm to enforce this to be unique but it bugged out last time...
-	InfoHash         string
+	InfoHash         metainfo.Hash
 	RatioToStop      float32 `json:"ratioToStop"`
 	MinutesAlive     int     `json:"minutesAlive"`
 	HoursToStop      int     `json:"hourseToStop"`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -123,9 +123,9 @@ type MovieTorrentLink struct {
 
 type TorrentMetaRepo interface {
 	Store(TorrentMeta) error
-	GetByInfoHashStr(string) (TorrentMeta, error)
+	GetByInfoHash(metainfo.Hash) (TorrentMeta, error)
 	Get() ([]TorrentMeta, error)
-	RemoveByInfoHashStr(hashStr string) error
+	RemoveByInfoHash(metainfo.Hash) error
 }
 
 type ReleaseRepo interface {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,7 +15,6 @@ func GetDefaultTorrentMeta() TorrentMeta {
 		HoursToStop: 336,
 		IsStopped:   false,
 	}
-
 }
 
 // These functions act as const arrays because go doesn't allow const arrays... I know pretty fucked up
@@ -44,13 +43,15 @@ type BasicAuth struct {
 type TorrentMeta struct {
 	ID int `storm:"id,increment"`
 	// Would like storm to enforce this to be unique but it bugged out last time...
-	InfoHash         metainfo.Hash
-	RatioToStop      float32 `json:"ratioToStop"`
-	MinutesAlive     int     `json:"minutesAlive"`
-	HoursToStop      int     `json:"hourseToStop"`
-	IsStopped        bool    `json:"isStopped"`
-	BytesWrittenData int64   `json:"bytesWrittenData"`
-	BytesReadData    int64   `json:"bytesReadData"`
+	InfoHash                     metainfo.Hash
+	RatioToStop                  float32 `json:"ratioToStop"`
+	SecondsAlive                 int     `json:"secondsAlive"`
+	SecondsSeedingWhileCompleted int     `json:"secondsSeedingWhileCompleted"`
+	HoursToStop                  int     `json:"hourseToStop"`
+	IsStopped                    bool    `json:"isStopped"`
+	BytesWrittenData             int64   `json:"bytesWrittenData"`
+	BytesReadData                int64   `json:"bytesReadData"`
+	DownloadSpeed                float32 `json:"downloadSpeed"`
 }
 
 // TorrentFile represents a file in a torrent

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 
 	"github.com/diericx/iceetime/internal/app"
+	"github.com/diericx/iceetime/internal/app/repos/storm"
 	"github.com/diericx/iceetime/internal/app/services"
 	"github.com/diericx/iceetime/internal/pkg/torrent"
 	"github.com/gin-contrib/cors"
@@ -25,6 +26,7 @@ type HTTPHandler struct {
 	ReleaseService     services.Release
 	TorrentLinkService services.TorrentLink
 	Transcoder         services.Transcoder
+	TorrentMetaRepo    storm.TorrentMeta
 	Qualities          []app.Quality
 	TorrentFilesPath   string
 }

--- a/internal/app/http/torrents.go
+++ b/internal/app/http/torrents.go
@@ -114,7 +114,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 			torrentResponses := make([]Torrent, len(torrents))
 
 			for i, t := range torrents {
-				meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
+				meta, err := h.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 				if err != nil {
 					torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, app.TorrentMeta{})
 					continue
@@ -158,7 +158,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
+			meta, err := h.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{
 					"error": err.Error(),

--- a/internal/app/http/torrents.go
+++ b/internal/app/http/torrents.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/anacrolix/torrent/metainfo"
+
 	"github.com/asdine/storm"
 	"github.com/diericx/iceetime/internal/app"
 	"github.com/diericx/iceetime/internal/pkg/torrent"
@@ -108,11 +110,11 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 		})
 
 		group.GET("/torrents", func(c *gin.Context) {
-			torrents, err := s.Get()
+			torrents := s.Get()
 			torrentResponses := make([]Torrent, len(torrents))
 
 			for i, t := range torrents {
-				meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
+				meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 				if err != nil {
 					torrentResponses[i] = newTorrentResponseFromInterfaceAndMetadata(t, app.TorrentMeta{})
 					continue
@@ -123,7 +125,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 
 			c.JSON(http.StatusOK, gin.H{
 				"torrents": torrentResponses,
-				"error":    err,
+				"error":    false,
 			})
 		})
 
@@ -140,7 +142,15 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			t, err := s.GetByInfoHashStr(input.InfoHash)
+			var infoHash metainfo.Hash
+			err := infoHash.FromHexString(input.InfoHash)
+			if err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
+				})
+			}
+
+			t, err := s.GetByInfoHash(infoHash)
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{
 					"error": err.Error(),
@@ -148,7 +158,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
+			meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 			if err != nil {
 				c.JSON(http.StatusOK, gin.H{
 					"error": err.Error(),
@@ -164,7 +174,7 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 		group.GET("/torrents/torrent/:infoHash/stream/:file", func(c *gin.Context) {
 			type Input struct {
 				InfoHash  string `uri:"infoHash" binding:"required"`
-				FileIndex int    `uri:"file"`
+				FileIndex uint   `uri:"file"`
 			}
 			var input Input
 
@@ -175,7 +185,15 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			t, err := s.GetByInfoHashStr(input.InfoHash)
+			var infoHash metainfo.Hash
+			err := infoHash.FromHexString(input.InfoHash)
+			if err != nil {
+				c.JSON(http.StatusOK, gin.H{
+					"error": err.Error(),
+				})
+			}
+
+			t, err := s.GetByInfoHash(infoHash)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error": err.Error(),
@@ -183,14 +201,14 @@ func (h *HTTPHandler) addTorrentsGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			readseeker, err := s.GetReadSeekerForFileInTorrent(t, input.FileIndex)
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"error": err.Error(),
+			files := t.Files()
+			if int(input.FileIndex) > len(files) {
+				c.JSON(http.StatusOK, gin.H{
+					"error": "File index not in range of files.",
 				})
-				return
 			}
 
+			readseeker := files[input.FileIndex].NewReader()
 			http.ServeContent(c.Writer, c.Request, t.Name(), time.Time{}, readseeker)
 		})
 

--- a/internal/app/repos/storm/torrentmeta.go
+++ b/internal/app/repos/storm/torrentmeta.go
@@ -14,13 +14,15 @@ func (r *TorrentMeta) Store(meta app.TorrentMeta) error {
 	return r.DB.Save(&meta)
 }
 
-func (r *TorrentMeta) GetByInfoHashStr(infoHash metainfo.Hash) (app.TorrentMeta, error) {
+// GetByInfoHash retrieves an app.TorrentMeta object from the db by info hash if exists, err if not
+func (r *TorrentMeta) GetByInfoHash(infoHash metainfo.Hash) (app.TorrentMeta, error) {
 	var meta app.TorrentMeta
 	meta.InfoHash = infoHash
 	err := r.DB.One("InfoHash", infoHash, &meta)
 	return meta, err
 }
 
+// Get retrieves all TorrentMeta objects in db
 func (r *TorrentMeta) Get() ([]app.TorrentMeta, error) {
 	var metas []app.TorrentMeta
 	err := r.DB.All(&metas)
@@ -28,6 +30,10 @@ func (r *TorrentMeta) Get() ([]app.TorrentMeta, error) {
 }
 
 func (r *TorrentMeta) RemoveByInfoHash(infoHash metainfo.Hash) error {
-	err := r.DB.DeleteStruct(app.TorrentMeta{InfoHash: infoHash})
+	meta, err := r.GetByInfoHash(infoHash)
+	if err != nil {
+		return err
+	}
+	err = r.DB.DeleteStruct(&meta)
 	return err
 }

--- a/internal/app/repos/storm/torrentmeta.go
+++ b/internal/app/repos/storm/torrentmeta.go
@@ -1,6 +1,7 @@
 package storm
 
 import (
+	"github.com/anacrolix/torrent/metainfo"
 	"github.com/asdine/storm"
 	"github.com/diericx/iceetime/internal/app"
 )
@@ -13,10 +14,10 @@ func (r *TorrentMeta) Store(meta app.TorrentMeta) error {
 	return r.DB.Save(&meta)
 }
 
-func (r *TorrentMeta) GetByInfoHashStr(infoHashStr string) (app.TorrentMeta, error) {
+func (r *TorrentMeta) GetByInfoHashStr(infoHash metainfo.Hash) (app.TorrentMeta, error) {
 	var meta app.TorrentMeta
-	meta.InfoHash = infoHashStr
-	err := r.DB.One("InfoHash", infoHashStr, &meta)
+	meta.InfoHash = infoHash
+	err := r.DB.One("InfoHash", infoHash, &meta)
 	return meta, err
 }
 
@@ -26,7 +27,7 @@ func (r *TorrentMeta) Get() ([]app.TorrentMeta, error) {
 	return metas, err
 }
 
-func (r *TorrentMeta) RemoveByInfoHashStr(hashStr string) error {
-	err := r.DB.DeleteStruct(app.TorrentMeta{InfoHash: hashStr})
+func (r *TorrentMeta) RemoveByInfoHash(infoHash metainfo.Hash) error {
+	err := r.DB.DeleteStruct(app.TorrentMeta{InfoHash: infoHash})
 	return err
 }

--- a/internal/app/repos/storm/torrentmeta_test.go
+++ b/internal/app/repos/storm/torrentmeta_test.go
@@ -3,6 +3,7 @@ package storm
 import (
 	"log"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/anacrolix/torrent/metainfo"
@@ -35,7 +36,7 @@ func (s state) cleanup() {
 	os.Remove(".test.storm.db")
 }
 
-func TestStore(t *testing.T) {
+func TestStoreAndGetByInfoHash(t *testing.T) {
 	state := setup()
 	defer state.cleanup()
 
@@ -43,13 +44,121 @@ func TestStore(t *testing.T) {
 		Comment: "test",
 	}
 	infoHash := meta.HashInfoBytes()
-	expectedMeta := app.TorrentMeta{
+	expected := app.TorrentMeta{
+		ID:       1,
 		InfoHash: infoHash,
 	}
 
-	err := state.TorrentMetaService.Store(expectedMeta)
+	err := state.TorrentMetaService.Store(expected)
 	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
+		t.Fatalf("Unexpected error storing: %s", err)
 	}
 
+	actual, err := state.TorrentMetaService.GetByInfoHash(infoHash)
+	if err != nil {
+		t.Fatalf("Unexpected error fetching: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected and actual are not the same: \n EXPECTED: \n %+v \n ACTUAL: \n %+v", expected, actual)
+	}
+}
+
+func TestGet(t *testing.T) {
+	state := setup()
+	defer state.cleanup()
+
+	expected := []app.TorrentMeta{
+		app.TorrentMeta{
+			ID: 1,
+			InfoHash: metainfo.MetaInfo{
+				Comment: "torrent-1",
+			}.HashInfoBytes(),
+		},
+		app.TorrentMeta{
+			ID: 2,
+			InfoHash: metainfo.MetaInfo{
+				Comment: "torrent-2",
+			}.HashInfoBytes(),
+		},
+	}
+
+	for _, meta := range expected {
+		err := state.TorrentMetaService.Store(meta)
+		if err != nil {
+			t.Fatalf("Unexpected error storing: %s", err)
+		}
+	}
+
+	actual, err := state.TorrentMetaService.Get()
+	if err != nil {
+		t.Fatalf("Unexpected error fetching: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected and actual are not the same: \n EXPECTED: \n %+v \n ACTUAL: \n %+v", expected, actual)
+	}
+}
+
+func TestGetByInfoHash(t *testing.T) {
+	state := setup()
+	defer state.cleanup()
+
+	meta := metainfo.MetaInfo{
+		Comment: "test",
+	}
+	infoHash := meta.HashInfoBytes()
+	expected := app.TorrentMeta{
+		ID:       1,
+		InfoHash: infoHash,
+	}
+
+	err := state.TorrentMetaService.Store(expected)
+	if err != nil {
+		t.Fatalf("Unexpected error storing: %s", err)
+	}
+
+	actual, err := state.TorrentMetaService.GetByInfoHash(infoHash)
+	if err != nil {
+		t.Fatalf("Unexpected error fetching: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected and actual are not the same: \n EXPECTED: \n %+v \n ACTUAL: \n %+v", expected, actual)
+	}
+}
+
+func Test(t *testing.T) {
+	state := setup()
+	defer state.cleanup()
+
+	meta := metainfo.MetaInfo{
+		Comment: "test",
+	}
+	infoHash := meta.HashInfoBytes()
+	mockTorrentMeta := app.TorrentMeta{
+		ID:       1,
+		InfoHash: infoHash,
+	}
+
+	expected := []app.TorrentMeta{}
+
+	err := state.TorrentMetaService.Store(mockTorrentMeta)
+	if err != nil {
+		t.Fatalf("Unexpected error storing: %s", err)
+	}
+
+	err = state.TorrentMetaService.RemoveByInfoHash(mockTorrentMeta.InfoHash)
+	if err != nil {
+		t.Fatalf("Unexpected error removing: %s", err)
+	}
+
+	actual, err := state.TorrentMetaService.Get()
+	if err != nil {
+		t.Fatalf("Unexpected error fetching: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("Expected and actual are not the same: \n EXPECTED: \n %+v \n ACTUAL: \n %+v", expected, actual)
+	}
 }

--- a/internal/app/repos/storm/torrentmeta_test.go
+++ b/internal/app/repos/storm/torrentmeta_test.go
@@ -1,0 +1,55 @@
+package storm
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/anacrolix/torrent/metainfo"
+	"github.com/diericx/iceetime/internal/app"
+
+	"github.com/asdine/storm"
+)
+
+type state struct {
+	DB                 *storm.DB
+	TorrentMetaService TorrentMeta
+}
+
+func setup() state {
+	stormDBFilePath := ".test.storm.db"
+	stormDB, err := OpenDB(stormDBFilePath)
+	if err != nil {
+		log.Fatalf("Couldn't open torrent file at %s. The file will be created if it doesn't exist, make sure the directory exists and user has proper permissions.", stormDBFilePath)
+	}
+
+	return state{
+		TorrentMetaService: TorrentMeta{
+			DB: stormDB,
+		},
+	}
+}
+
+func (s state) cleanup() {
+	s.TorrentMetaService.DB.Close()
+	os.Remove(".test.storm.db")
+}
+
+func TestStore(t *testing.T) {
+	state := setup()
+	defer state.cleanup()
+
+	meta := metainfo.MetaInfo{
+		Comment: "test",
+	}
+	infoHash := meta.HashInfoBytes()
+	expectedMeta := app.TorrentMeta{
+		InfoHash: infoHash,
+	}
+
+	err := state.TorrentMetaService.Store(expectedMeta)
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+
+}

--- a/internal/app/services/torrent.go
+++ b/internal/app/services/torrent.go
@@ -51,11 +51,11 @@ func (s *Torrent) UpdateMetaForAllTorrents() error {
 		}
 
 		stats := t.Stats()
-		cachedStats, ok := s.torrentStatCache[t.InfoHash().HexString()]
+		cachedStats, ok := s.torrentStatCache[t.InfoHash()]
 
 		// Add cache and move on if doesn't exist yet
 		if !ok {
-			s.torrentStatCache[t.InfoHash().HexString()] = t.Stats()
+			s.torrentStatCache[t.InfoHash()] = t.Stats()
 			continue
 		}
 
@@ -64,7 +64,7 @@ func (s *Torrent) UpdateMetaForAllTorrents() error {
 
 		// If there is a difference, update meta with diff
 		if bytesReadDataDiff > 0 || bytesWrittenDataDiff > 0 {
-			meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
+			meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 			// if meta doesn't exist, torrent might just be still connecting. Just move on
 			if err != nil {
 				log.Println("ERROR: ", err)
@@ -75,7 +75,7 @@ func (s *Torrent) UpdateMetaForAllTorrents() error {
 			meta.BytesWrittenData += bytesWrittenDataDiff
 			s.TorrentMetaRepo.Store(meta)
 
-			s.torrentStatCache[t.InfoHash().HexString()] = t.Stats()
+			s.torrentStatCache[t.InfoHash()] = t.Stats()
 		}
 	}
 	return nil
@@ -120,7 +120,7 @@ func (s *Torrent) StartTorrentsAccordingToMetadata() error {
 
 	for _, t := range torrents {
 		// Get meta
-		meta, err := s.TorrentMetaRepo.GetByInfoHashStr(t.InfoHash().HexString())
+		meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
 		if err != nil {
 			return err
 		}

--- a/internal/app/services/torrent.go
+++ b/internal/app/services/torrent.go
@@ -20,68 +20,97 @@ import (
 )
 
 type Torrent struct {
-	Client           app.TorrentClient
-	TorrentMetaRepo  app.TorrentMetaRepo
-	GetInfoTimeout   time.Duration
-	MinSeeders       int
-	TorrentFilesPath string
+	client           app.TorrentClient
+	torrentMetaRepo  app.TorrentMetaRepo
+	getInfoTimeout   time.Duration
+	minSeeders       int
+	torrentFilesPath string
 
 	torrentStatCache torrent.StatCache
 }
 
-// UpdateMetaForAllTorrents goes through the current torrents in the client, takes a diff between what
+func NewTorrentService(client app.TorrentClient, tmr app.TorrentMetaRepo, getInfoTimeout time.Duration, minSeeders int, torrentFilesPath string) Torrent {
+	return Torrent{
+		client,
+		tmr,
+		getInfoTimeout,
+		minSeeders,
+		torrentFilesPath,
+		make(torrent.StatCache),
+	}
+}
+
+// StartMetaRefreshForAllTorrentsLoop goes through the current torrents in the client, takes a diff between what
 // it and it's stored metadata, then updates the meta with said diff.
-func (s *Torrent) UpdateMetaForAllTorrents() error {
-	if s.torrentStatCache == nil {
-		s.torrentStatCache = make(torrent.StatCache)
-	}
+func (s *Torrent) StartMetaRefreshForAllTorrentsLoop(refreshRateInSeconds int) error {
+	for {
+		time.Sleep(time.Duration(refreshRateInSeconds) * time.Second)
 
-	torrentMetas, err := s.TorrentMetaRepo.Get()
-	if err != nil {
-		return err
-	}
-	for _, torrentMeta := range torrentMetas {
-		t, ok := s.Client.Torrent(torrentMeta.InfoHash)
-		if !ok {
-			log.Println("Error updating meta: torrent does not exist in client")
-			continue
+		if s.torrentStatCache == nil {
+			s.torrentStatCache = make(torrent.StatCache)
 		}
 
-		stats := t.Stats()
-		cachedStats, ok := s.torrentStatCache[t.InfoHash()]
-
-		// Add cache and move on if doesn't exist yet
-		if !ok {
-			s.torrentStatCache[t.InfoHash()] = t.Stats()
-			continue
+		torrentMetas, err := s.torrentMetaRepo.Get()
+		if err != nil {
+			return err
 		}
-
-		bytesWrittenDataDiff := stats.BytesWrittenData.Int64() - cachedStats.BytesWrittenData.Int64()
-		bytesReadDataDiff := stats.BytesReadData.Int64() - cachedStats.BytesReadData.Int64()
-
-		// If there is a difference, update meta with diff
-		if bytesReadDataDiff > 0 || bytesWrittenDataDiff > 0 {
-			meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
-			// if meta doesn't exist, torrent might just be still connecting. Just move on
-			if err != nil {
-				log.Println("ERROR: ", err)
+		for _, torrentMeta := range torrentMetas {
+			t, ok := s.client.Torrent(torrentMeta.InfoHash)
+			if !ok {
+				log.Println("Error updating meta: torrent does not exist in client")
 				continue
 			}
 
-			meta.BytesReadData += bytesReadDataDiff
-			meta.BytesWrittenData += bytesWrittenDataDiff
-			s.TorrentMetaRepo.Store(meta)
+			stats := t.Stats()
+			cachedStats, ok := s.torrentStatCache[t.InfoHash()]
 
-			s.torrentStatCache[t.InfoHash()] = t.Stats()
+			// Add cache and move on if doesn't exist yet
+			if !ok {
+				s.torrentStatCache[t.InfoHash()] = t.Stats()
+				continue
+			}
+
+			bytesWrittenDataDiff := stats.BytesWrittenData.Int64() - cachedStats.BytesWrittenData.Int64()
+			bytesReadDataDiff := stats.BytesReadData.Int64() - cachedStats.BytesReadData.Int64()
+
+			meta, err := s.torrentMetaRepo.GetByInfoHash(t.InfoHash())
+
+			// If there is a difference, update meta with diff
+			if bytesReadDataDiff > 0 || bytesWrittenDataDiff > 0 {
+				// if meta doesn't exist, torrent might just be still connecting. Just move on
+				if err != nil {
+					log.Println("ERROR: ", err)
+					continue
+				}
+
+				meta.BytesReadData += bytesReadDataDiff
+				meta.BytesWrittenData += bytesWrittenDataDiff
+				meta.SecondsAlive += refreshRateInSeconds
+				meta.DownloadSpeed = float32(bytesReadDataDiff) / float32(refreshRateInSeconds)
+				// if it's completed downloading and seeding, start incrementing seed time
+				if t.BytesMissing() == 0 && t.Seeding() {
+					meta.SecondsSeedingWhileCompleted += refreshRateInSeconds
+				}
+
+				s.torrentMetaRepo.Store(meta)
+
+				s.torrentStatCache[t.InfoHash()] = t.Stats()
+			} else {
+				// Nothing downloaded so make sure download speed is set to 0
+				if meta.DownloadSpeed != 0 {
+					meta.DownloadSpeed = 0
+					s.torrentMetaRepo.Store(meta)
+					s.torrentStatCache[t.InfoHash()] = t.Stats()
+				}
+			}
 		}
 	}
-	return nil
 }
 
 // AddTorrentsOnDisk adds all torrent files in a dir then async waits for info
 func (s *Torrent) AddTorrentsOnDisk() error {
 	var files []string
-	err := filepath.Walk(s.TorrentFilesPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(s.torrentFilesPath, func(path string, info os.FileInfo, err error) error {
 		if filepath.Ext(path) == ".torrent" {
 			files = append(files, path)
 		}
@@ -93,7 +122,7 @@ func (s *Torrent) AddTorrentsOnDisk() error {
 
 	var wg sync.WaitGroup
 	for _, file := range files {
-		t, err := s.Client.AddFile(file)
+		t, err := s.client.AddFile(file)
 		if err != nil {
 			log.Printf("ERROR: Could not add file: %s\n", file)
 		}
@@ -114,7 +143,7 @@ func (s *Torrent) StartTorrentsAccordingToMetadata() error {
 
 	for _, t := range torrents {
 		// Get meta
-		meta, err := s.TorrentMetaRepo.GetByInfoHash(t.InfoHash())
+		meta, err := s.torrentMetaRepo.GetByInfoHash(t.InfoHash())
 		if err != nil {
 			return err
 		}
@@ -129,20 +158,20 @@ func (s *Torrent) StartTorrentsAccordingToMetadata() error {
 // AddFromMagnet adds a magnet, saves the torrent info to a file and saves metadata with
 // resulting torrent's info hash
 func (s *Torrent) AddFromMagnet(magnet string, meta app.TorrentMeta) (torrent.Torrent, error) {
-	t, err := s.Client.AddMagnet(magnet)
+	t, err := s.client.AddMagnet(magnet)
 	if err != nil {
 		return nil, err
 	}
 	select {
 	case <-t.GotInfo():
-	case <-time.After(s.GetInfoTimeout):
+	case <-time.After(s.getInfoTimeout):
 		t.Drop()
 		return nil, errors.New("info grab timed out")
 	}
 
 	// Save our custom meta
 	meta.InfoHash = t.InfoHash()
-	err = s.TorrentMetaRepo.Store(meta)
+	err = s.torrentMetaRepo.Store(meta)
 	if err != nil {
 		t.Drop()
 		return nil, err
@@ -165,20 +194,20 @@ func (s *Torrent) AddFromMagnet(magnet string, meta app.TorrentMeta) (torrent.To
 // AddFromFile adds a torrent from a file and creates it's own file in the files directory.
 // A TorrentMeta is saved with the resulting torrent info hash.
 func (s *Torrent) AddFromFile(file string, meta app.TorrentMeta) (torrent.Torrent, error) {
-	t, err := s.Client.AddFile(file)
+	t, err := s.client.AddFile(file)
 	if err != nil {
 		return nil, err
 	}
 	select {
 	case <-t.GotInfo():
-	case <-time.After(s.GetInfoTimeout):
+	case <-time.After(s.getInfoTimeout):
 		t.Drop()
 		return nil, errors.New("info grab timed out")
 	}
 
 	// Save our custom meta
 	meta.InfoHash = t.InfoHash()
-	err = s.TorrentMetaRepo.Store(meta)
+	err = s.torrentMetaRepo.Store(meta)
 	if err != nil {
 		t.Drop()
 		return nil, err
@@ -194,58 +223,12 @@ func (s *Torrent) AddFromFile(file string, meta app.TorrentMeta) (torrent.Torren
 	return t, nil
 }
 
-// addFromURLUknownScheme will add the torrent if it is a magnet url, will download a file if it's a
-// file or recursicely follow a redirect
-func (s *Torrent) addFromURLUknownScheme(rawURL string, auth *app.BasicAuth, meta app.TorrentMeta) (torrent.Torrent, error) {
-	u, err := url.Parse(rawURL)
-	if err != nil {
-		return nil, err
-	}
-	if u.Scheme == "magnet" {
-		return s.AddFromMagnet(rawURL, meta)
-	}
-
-	// Attempt to make http/s call
-	req, err := http.NewRequest("GET", rawURL, nil)
-	if err != nil {
-		panic(err)
-	}
-	if auth != nil {
-		req.SetBasicAuth(auth.Username, auth.Password)
-	}
-	client := new(http.Client)
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		return errors.New("Redirect")
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		if resp.StatusCode == http.StatusFound { //status code 302
-			url, err := resp.Location()
-			if err != nil {
-				return nil, err
-			}
-			return s.addFromURLUknownScheme(url.String(), auth, meta)
-		}
-		return nil, err
-	}
-
-	tempFilePath := fmt.Sprintf("%s/%s", s.TorrentFilesPath, randomString(10))
-	err = downloadFileFromResponse(resp, tempFilePath)
-	defer os.Remove(tempFilePath)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.AddFromFile(tempFilePath, meta)
-}
-
 func (s *Torrent) Get() []torrent.Torrent {
-	return s.Client.Torrents()
+	return s.client.Torrents()
 }
 
 func (s *Torrent) GetByInfoHash(infoHash metainfo.Hash) (torrent.Torrent, error) {
-	t, ok := s.Client.Torrent(infoHash)
+	t, ok := s.client.Torrent(infoHash)
 	if !ok {
 		return nil, errors.New("torrent not found")
 	}
@@ -263,8 +246,8 @@ func (s *Torrent) AddBestTorrentFromReleases(releases []app.Release, q app.Quali
 			log.Printf("INFO: Passing on release %s because size %v is not correct.", r.Title, r.Size)
 			continue
 		}
-		if r.Seeders < s.MinSeeders {
-			log.Printf("INFO: Passing on release %s because seeders: %v is less than minimum: %v", r.Title, r.Seeders, s.MinSeeders)
+		if r.Seeders < s.minSeeders {
+			log.Printf("INFO: Passing on release %s because seeders: %v is less than minimum: %v", r.Title, r.Seeders, s.minSeeders)
 			continue
 		}
 		if stringContainsAnyOf(strings.ToLower(r.Title), app.GetBlacklistedTorrentNameContents()) {
@@ -306,19 +289,65 @@ func (s *Torrent) AddBestTorrentFromReleases(releases []app.Release, q app.Quali
 }
 
 func (s *Torrent) RemoveByHash(hash metainfo.Hash) error {
-	t, ok := s.Client.Torrent(hash)
+	t, ok := s.client.Torrent(hash)
 	if !ok {
 		return errors.New("not found")
 	}
 
 	t.Drop()
 
-	err := s.TorrentMetaRepo.RemoveByInfoHash(hash)
+	err := s.torrentMetaRepo.RemoveByInfoHash(hash)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// addFromURLUknownScheme will add the torrent if it is a magnet url, will download a file if it's a
+// file or recursicely follow a redirect
+func (s *Torrent) addFromURLUknownScheme(rawURL string, auth *app.BasicAuth, meta app.TorrentMeta) (torrent.Torrent, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme == "magnet" {
+		return s.AddFromMagnet(rawURL, meta)
+	}
+
+	// Attempt to make http/s call
+	req, err := http.NewRequest("GET", rawURL, nil)
+	if err != nil {
+		panic(err)
+	}
+	if auth != nil {
+		req.SetBasicAuth(auth.Username, auth.Password)
+	}
+	client := new(http.Client)
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return errors.New("Redirect")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if resp.StatusCode == http.StatusFound { //status code 302
+			url, err := resp.Location()
+			if err != nil {
+				return nil, err
+			}
+			return s.addFromURLUknownScheme(url.String(), auth, meta)
+		}
+		return nil, err
+	}
+
+	tempFilePath := fmt.Sprintf("%s/%s", s.torrentFilesPath, randomString(10))
+	err = downloadFileFromResponse(resp, tempFilePath)
+	defer os.Remove(tempFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.AddFromFile(tempFilePath, meta)
 }
 
 func (s *Torrent) getValidFileInTorrent(t torrent.Torrent) (int, error) {
@@ -353,7 +382,7 @@ func downloadFileFromResponse(resp *http.Response, filePath string) error {
 }
 
 func (s *Torrent) saveTorrentToFile(t torrent.Torrent) (err error) {
-	file := filepath.Join(s.TorrentFilesPath, fmt.Sprintf("%s.torrent", t.InfoHash().HexString()))
+	file := filepath.Join(s.torrentFilesPath, fmt.Sprintf("%s.torrent", t.InfoHash().HexString()))
 	f, err := os.OpenFile(file, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0660)
 	if err != nil {
 		return

--- a/internal/pkg/torrent/client.go
+++ b/internal/pkg/torrent/client.go
@@ -7,6 +7,8 @@ import (
 
 type Torrent interface {
 	BytesCompleted() int64
+	BytesMissing() int64
+	Seeding() bool
 	GotInfo() <-chan struct{}
 	Drop()
 	DownloadAll()

--- a/internal/pkg/torrent/client.go
+++ b/internal/pkg/torrent/client.go
@@ -18,7 +18,7 @@ type Torrent interface {
 	Stats() torrent.TorrentStats
 }
 
-type StatCache map[string]torrent.TorrentStats
+type StatCache map[metainfo.Hash]torrent.TorrentStats
 
 type Client struct {
 	*torrent.Client


### PR DESCRIPTION
- Using metainfo.Hash instead of converting back and forth between strings
- Now capturing data from refresh loop in metadata and displaying back to client (like download speed and seed time)

resolves #29 