### PR TITLE
Talk to TMDB through the backend instead of directly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/diericx/iceetime/internal/app/http"
 	"github.com/diericx/iceetime/internal/app/repos/jackett"
 	"github.com/diericx/iceetime/internal/app/repos/storm"
+	"github.com/diericx/iceetime/internal/app/repos/tmdb"
 	"github.com/diericx/iceetime/internal/app/services"
 
 	"github.com/diericx/iceetime/internal/pkg/torrent"
@@ -21,7 +22,7 @@ type tomlConfig struct {
 	Indexers      []app.Indexer           `toml:"indexers"`
 	Qualities     []app.Quality           `toml:"qualities"`
 	Transcoder    app.TranscoderConfig    `toml:"transcoder"`
-	TmdbAPIKey    string                  `toml:"tmdb_api_key"`
+	Tmdb          app.TmdbConfig          `toml:"tmdb"`
 	TorrentClient app.TorrentClientConfig `toml:"torrent_client"`
 }
 
@@ -52,6 +53,10 @@ func main() {
 	//
 	// Initialize repos
 	//
+	tmdbRepo := tmdb.TmdbRepo{
+		APIKey: conf.Tmdb.APIKey,
+	}
+
 	torrentMetaRepo := storm.TorrentMeta{
 		DB: stormDB,
 	}
@@ -68,6 +73,10 @@ func main() {
 	//
 	// Initialize services
 	//
+	tmdbService := services.Tmdb{
+		TmdbRepo: tmdbRepo,
+	}
+
 	torrentService := services.NewTorrentService(
 		client,
 		&torrentMetaRepo,
@@ -104,6 +113,7 @@ func main() {
 	}
 
 	httpHandler := http.HTTPHandler{
+		TmdbService:        tmdbService,
 		TorrentService:     torrentService,
 		ReleaseService:     releaseService,
 		TorrentLinkService: torrentLinkService,

--- a/config-example.toml
+++ b/config-example.toml
@@ -1,4 +1,5 @@
-tmdb_apiKey = ""
+[tmdb]
+  api_key = ""
 
 [[indexers]]
   name = "My Indexer"

--- a/frontend/src/components/TorrentStream/index.js
+++ b/frontend/src/components/TorrentStream/index.js
@@ -30,8 +30,6 @@ export default class MyComponent extends React.Component {
     const { movie } = this.props;
     const { torrentLink, isLoading, error } = this.state;
 
-    let releaseDate = movie.release_date.split('-')[0];
-
     if (error) {
       return (
         <Alert variant={'danger'} style={{ width: '80%' }}>
@@ -64,9 +62,9 @@ export default class MyComponent extends React.Component {
           variant="primary"
           onClick={async () => {
             this.findTorrent(
-              movie.externalIDs.imdb_id,
+              movie.imdb_id,
               movie.title,
-              releaseDate
+              movie.release_year
             );
             this.setState({ isLoading: true });
           }}

--- a/frontend/src/pages/movie.js
+++ b/frontend/src/pages/movie.js
@@ -23,9 +23,8 @@ export default class MyComponent extends React.Component {
       },
     } = this.props;
     if (!movie.externalIDs) {
-      let tmdbAPIKey = process.env.REACT_APP_TMDB_API_KEY;
       fetch(
-        `https://api.themoviedb.org/3/movie/${movie.id}/external_ids?api_key=${tmdbAPIKey}`
+        `${backendURL}/v1/tmdb/movies/${movie.id}`
       )
         .then((res) => res.json())
         .then(
@@ -34,7 +33,7 @@ export default class MyComponent extends React.Component {
               isLoaded: true,
               movie: {
                 ...movie,
-                externalIDs: result,
+                imdb_id: result.imdb_id,
               },
             });
           },
@@ -66,7 +65,7 @@ export default class MyComponent extends React.Component {
       <Container fluid>
         <Row
           style={{
-            backgroundImage: `url("https://image.tmdb.org/t/p/original${movie.backdrop_path}")`,
+            backgroundImage: `url("${movie.backdrop_url}")`,
           }}
           className={'movie-banner-row'}
         >
@@ -76,7 +75,7 @@ export default class MyComponent extends React.Component {
                 <Col sm={12} md={3}>
                   <img
                     className={'movie-poster'}
-                    src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+                    src={`${movie.poster_url}`}
                   ></img>
                 </Col>
                 <Col sm={12} md={6} className={'movie-details'}>

--- a/frontend/src/pages/movies.js
+++ b/frontend/src/pages/movies.js
@@ -16,6 +16,7 @@ const styles = {
   },
 };
 
+let backendURL = window._env_.BACKEND_URL;
 let tmdbAPIKey = window._env_.REACT_APP_TMDB_API_KEY;
 
 export default class MyComponent extends React.Component {
@@ -48,7 +49,7 @@ export default class MyComponent extends React.Component {
   };
 
   componentDidMount() {
-    fetch(`https://api.themoviedb.org/3/movie/popular?api_key=${tmdbAPIKey}`)
+    fetch(`${backendURL}/v1/tmdb/browse/movies/popular`)
       .then((res) => res.json())
       .then(
         (result) => {
@@ -129,10 +130,16 @@ export default class MyComponent extends React.Component {
                     state: { movie: item },
                   }}
                 >
+                {!item.poster_url ? (
                   <Card.Img
                     variant="top"
-                    src={`https://image.tmdb.org/t/p/w500${item.poster_path}`}
                   />
+                ) : (
+                  <Card.Img
+                    variant="top"
+                    src={`${item.poster_url}`}
+                  />
+                )}
                 </Link>
                 <Card.Body>
                   <Card.Title>

--- a/frontend/src/pages/search.js
+++ b/frontend/src/pages/search.js
@@ -8,6 +8,8 @@ import Col from 'react-bootstrap/Col';
 import Card from 'react-bootstrap/Card';
 import './search.css';
 
+let backendURL = window._env_.BACKEND_URL;
+
 export default class MyComponent extends React.Component {
   state = {
     query: null,
@@ -22,7 +24,7 @@ export default class MyComponent extends React.Component {
     } = this.props;
     let tmdbAPIKey = process.env.REACT_APP_TMDB_API_KEY;
     fetch(
-      `https://api.themoviedb.org/3/search/movie?api_key=${tmdbAPIKey}&query=${query}`
+      `${backendURL}/v1/tmdb/search/movies?query=${query}`
     )
       .then((res) => res.json())
       .then(
@@ -83,11 +85,18 @@ export default class MyComponent extends React.Component {
                         state: { movie: item },
                       }}
                     >
-                      <Card.Img
-                        variant="top"
-                        className="movie-card-img"
-                        src={`https://image.tmdb.org/t/p/w500${item.poster_path}`}
-                      />
+                      {!item.poster_url ? (
+                        <Card.Img
+                          variant="top"
+                          className="movie-card-img"
+                        />
+                      ) : (
+                        <Card.Img
+                          variant="top"
+                          className="movie-card-img"
+                          src={`${item.poster_url}`}
+                        />
+                      )}
                     </Link>
                   </Col>
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -85,6 +85,10 @@ type TorrentClientConfig struct {
 	MetaRefreshRate                   int    `toml:"meta_refresh_rate"`
 }
 
+type TmdbConfig struct {
+	APIKey string `toml:"api_key"`
+}
+
 // Indexer is info we need to hit an indexer for a list of torrents
 type Indexer struct {
 	Name                 string     `toml:"name"`

--- a/internal/app/http/handler.go
+++ b/internal/app/http/handler.go
@@ -22,6 +22,7 @@ type Metadata struct {
 }
 
 type HTTPHandler struct {
+	TmdbService        services.Tmdb
 	TorrentService     services.Torrent
 	ReleaseService     services.Release
 	TorrentLinkService services.TorrentLink
@@ -54,6 +55,7 @@ func (h *HTTPHandler) Serve(cookieSecret string) {
 
 	v1 := r.Group("/v1")
 
+	h.addTmdbGroup(v1)
 	h.addTorrentsGroup(v1)
 	h.addTranscoderGroup(v1)
 

--- a/internal/app/http/tmdb.go
+++ b/internal/app/http/tmdb.go
@@ -24,7 +24,7 @@ func (h *HTTPHandler) addTmdbGroup(group *gin.RouterGroup) {
 				return
 			}
 
-			result, err := s.PoplarMovies(params.Page)
+			result, err := s.PopularMovies(params.Page)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"error": err,

--- a/internal/app/http/tmdb.go
+++ b/internal/app/http/tmdb.go
@@ -1,0 +1,81 @@
+package http
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (h *HTTPHandler) addTmdbGroup(group *gin.RouterGroup) {
+	s := h.TmdbService
+
+	{
+		group.GET("/tmdb/browse/movies/popular", func(c *gin.Context) {
+			type PopularParams struct {
+				Page int `form:"page,default=1"`
+			}
+			var params PopularParams
+
+			if c.Bind(&params) != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "bad query params",
+				})
+				return
+			}
+
+			result, err := s.PoplarMovies(params.Page)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": err,
+				})
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		})
+
+		group.GET("/tmdb/search/movies", func(c *gin.Context) {
+			type SearchParams struct {
+				Query string `form:"query" binding:"required"`
+				Page  int    `form:"page,default=1"`
+			}
+			var params SearchParams
+
+			if c.Bind(&params) != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "bad query params",
+				})
+				return
+			}
+
+			result, err := s.MovieSearch(params.Query, params.Page)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": err,
+				})
+				return
+			}
+			c.JSON(http.StatusOK, result)
+		})
+
+		group.GET("/tmdb/movies/:movieID", func(c *gin.Context) {
+			movieIdStr := c.Params.ByName("movieID")
+			movieID, err := strconv.Atoi(movieIdStr)
+			if err != nil {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"error": "'movieID' is not a number. Found '" + movieIdStr + "'.",
+				})
+				return
+			}
+
+			movie, err := s.GetMovie(movieID)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"error": err,
+				})
+				return
+			}
+			c.JSON(http.StatusOK, movie)
+		})
+	}
+}

--- a/internal/app/repos/tmdb/tmdb.go
+++ b/internal/app/repos/tmdb/tmdb.go
@@ -1,0 +1,115 @@
+package tmdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+type TmdbRepo struct {
+	APIKey string
+}
+
+type QueryResultItem struct {
+	Id           int    `json:"id"`
+	Title        string `json:"title"`
+	Overview     string `json:"overview"`
+	PosterPath   string `json:"poster_path"`
+	BackdropPath string `json:"backdrop_path"`
+	ReleaseDate  string `json:"release_date"`
+}
+
+type QueryResult struct {
+	Results      []QueryResultItem `json:"results"`
+	TotalResults int               `json:"total_results"`
+	Page         int               `json:"page"`
+	TotalPages   int               `json:"total_pages"`
+}
+
+type Movie struct {
+	Id           int    `json:"id"`
+	Title        string `json:"title"`
+	Overview     string `json:"overview"`
+	PosterPath   string `json:"poster_path"`
+	BackdropPath string `json:"backdrop_path"`
+	ReleaseDate  string `json:"release_date"`
+	ImdbId       string `json:"imdb_id"`
+}
+
+func (s *TmdbRepo) PoplarMovies(page int) (QueryResult, error) {
+	var result QueryResult
+	url := fmt.Sprintf(
+		"https://api.themoviedb.org/3/movie/popular?api_key=%s&page=%d",
+		url.QueryEscape(s.APIKey),
+		page,
+	)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return result, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (s *TmdbRepo) MovieSearch(query string, page int) (QueryResult, error) {
+	var result QueryResult
+	url := fmt.Sprintf(
+		"https://api.themoviedb.org/3/search/movie?api_key=%s&query=%s&page=%d",
+		url.QueryEscape(s.APIKey),
+		url.QueryEscape(query),
+		page,
+	)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return result, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (s *TmdbRepo) GetMovie(id int) (Movie, error) {
+	var result Movie
+	url := fmt.Sprintf(
+		"https://api.themoviedb.org/3/movie/%d?api_key=%s",
+		id,
+		url.QueryEscape(s.APIKey),
+	)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return result, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return result, err
+	}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}

--- a/internal/app/repos/tmdb/tmdb.go
+++ b/internal/app/repos/tmdb/tmdb.go
@@ -38,7 +38,7 @@ type Movie struct {
 	ImdbId       string `json:"imdb_id"`
 }
 
-func (s *TmdbRepo) PoplarMovies(page int) (QueryResult, error) {
+func (s *TmdbRepo) PopularMovies(page int) (QueryResult, error) {
 	var result QueryResult
 	url := fmt.Sprintf(
 		"https://api.themoviedb.org/3/movie/popular?api_key=%s&page=%d",

--- a/internal/app/services/tmdb.go
+++ b/internal/app/services/tmdb.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"strings"
+
+	"github.com/diericx/iceetime/internal/app/repos/tmdb"
+)
+
+type Tmdb struct {
+	TmdbRepo tmdb.TmdbRepo
+}
+
+type QueryResultItem struct {
+	Id          int    `json:"id"`
+	Title       string `json:"title"`
+	Overview    string `json:"overview"`
+	PosterUrl   string `json:"poster_url"`
+	BackdropUrl string `json:"backdrop_url"`
+	ReleaseYear string `json:"release_year"`
+}
+
+type QueryResult struct {
+	Results      []QueryResultItem `json:"results"`
+	TotalResults int               `json:"total_results"`
+	Page         int               `json:"page"`
+	TotalPages   int               `json:"total_pages"`
+}
+
+type Movie struct {
+	Id          int    `json:"id"`
+	Title       string `json:"title"`
+	Overview    string `json:"overview"`
+	PosterUrl   string `json:"poster_url"`
+	BackdropUrl string `json:"backdrop_url"`
+	ReleaseYear string `json:"release_year"`
+	ImdbId      string `json:"imdb_id"`
+}
+
+func (s *Tmdb) PoplarMovies(page int) (QueryResult, error) {
+	var result QueryResult
+
+	repoResult, err := s.TmdbRepo.PoplarMovies(page)
+	if err != nil {
+		return result, err
+	}
+
+	result, err = ConvertQueryResult(repoResult)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (s *Tmdb) MovieSearch(query string, page int) (QueryResult, error) {
+	var result QueryResult
+
+	repoResult, err := s.TmdbRepo.MovieSearch(query, page)
+	if err != nil {
+		return result, err
+	}
+
+	result, err = ConvertQueryResult(repoResult)
+	if err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (s *Tmdb) GetMovie(id int) (Movie, error) {
+	var movie Movie
+
+	repoMovie, err := s.TmdbRepo.GetMovie(id)
+	if err != nil {
+		return movie, err
+	}
+
+	movie, err = ConvertMovie(repoMovie)
+	if err != nil {
+		return movie, err
+	}
+	return movie, nil
+}
+
+func ConvertQueryResult(repoResult tmdb.QueryResult) (QueryResult, error) {
+	var result QueryResult
+
+	result.Page = repoResult.Page
+	result.TotalPages = repoResult.TotalPages
+	result.TotalResults = repoResult.TotalResults
+	result.Results = make([]QueryResultItem, len(repoResult.Results))
+
+	for i, s := range repoResult.Results {
+
+		result.Results[i].Id = s.Id
+		result.Results[i].Title = s.Title
+		result.Results[i].Overview = s.Overview
+
+		// convert poster/backdrop paths to urls
+		result.Results[i].PosterUrl = PosterPathToPosterUrl(s.PosterPath)
+		result.Results[i].BackdropUrl = PosterPathToPosterUrl(s.BackdropPath)
+
+		// convert dates to years
+		year, err := ReleaseDateToReleaseYear(s.ReleaseDate)
+		if err != nil {
+			return result, err
+		}
+		result.Results[i].ReleaseYear = year
+	}
+
+	return result, nil
+}
+
+func ConvertMovie(repoMovie tmdb.Movie) (Movie, error) {
+	var movie Movie
+
+	movie.Id = repoMovie.Id
+	movie.Title = repoMovie.Title
+	movie.Overview = repoMovie.Overview
+	movie.ImdbId = repoMovie.ImdbId
+
+	// convert poster/backdrop paths to urls
+	movie.PosterUrl = PosterPathToPosterUrl(repoMovie.PosterPath)
+	movie.BackdropUrl = PosterPathToPosterUrl(repoMovie.BackdropPath)
+
+	// convert dates to years
+	year, err := ReleaseDateToReleaseYear(repoMovie.ReleaseDate)
+	if err != nil {
+		return movie, err
+	}
+	movie.ReleaseYear = year
+
+	return movie, nil
+}
+
+func ReleaseDateToReleaseYear(releaseDate string) (string, error) {
+	if releaseDate == "" {
+		return "", nil
+	}
+	dateSplit := strings.Split(releaseDate, "-")
+	return dateSplit[0], nil
+}
+
+func PosterPathToPosterUrl(posterPath string) string {
+	if posterPath != "" {
+		return "https://image.tmdb.org/t/p/w500" + posterPath
+	}
+	return ""
+}
+
+func BackdropPathToBackdropUrl(backdropPath string) string {
+	if backdropPath != "" {
+		return "https://image.tmdb.org/t/p/original" + backdropPath
+	}
+	return ""
+}

--- a/internal/app/services/tmdb.go
+++ b/internal/app/services/tmdb.go
@@ -36,10 +36,10 @@ type Movie struct {
 	ImdbId      string `json:"imdb_id"`
 }
 
-func (s *Tmdb) PoplarMovies(page int) (QueryResult, error) {
+func (s *Tmdb) PopularMovies(page int) (QueryResult, error) {
 	var result QueryResult
 
-	repoResult, err := s.TmdbRepo.PoplarMovies(page)
+	repoResult, err := s.TmdbRepo.PopularMovies(page)
 	if err != nil {
 		return result, err
 	}
@@ -98,11 +98,11 @@ func ConvertQueryResult(repoResult tmdb.QueryResult) (QueryResult, error) {
 		result.Results[i].Overview = s.Overview
 
 		// convert poster/backdrop paths to urls
-		result.Results[i].PosterUrl = PosterPathToPosterUrl(s.PosterPath)
-		result.Results[i].BackdropUrl = PosterPathToPosterUrl(s.BackdropPath)
+		result.Results[i].PosterUrl = posterPathToPosterUrl(s.PosterPath)
+		result.Results[i].BackdropUrl = posterPathToPosterUrl(s.BackdropPath)
 
 		// convert dates to years
-		year, err := ReleaseDateToReleaseYear(s.ReleaseDate)
+		year, err := releaseDateToReleaseYear(s.ReleaseDate)
 		if err != nil {
 			return result, err
 		}
@@ -121,11 +121,11 @@ func ConvertMovie(repoMovie tmdb.Movie) (Movie, error) {
 	movie.ImdbId = repoMovie.ImdbId
 
 	// convert poster/backdrop paths to urls
-	movie.PosterUrl = PosterPathToPosterUrl(repoMovie.PosterPath)
-	movie.BackdropUrl = PosterPathToPosterUrl(repoMovie.BackdropPath)
+	movie.PosterUrl = posterPathToPosterUrl(repoMovie.PosterPath)
+	movie.BackdropUrl = backdropPathToBackdropUrl(repoMovie.BackdropPath)
 
 	// convert dates to years
-	year, err := ReleaseDateToReleaseYear(repoMovie.ReleaseDate)
+	year, err := releaseDateToReleaseYear(repoMovie.ReleaseDate)
 	if err != nil {
 		return movie, err
 	}
@@ -134,7 +134,7 @@ func ConvertMovie(repoMovie tmdb.Movie) (Movie, error) {
 	return movie, nil
 }
 
-func ReleaseDateToReleaseYear(releaseDate string) (string, error) {
+func releaseDateToReleaseYear(releaseDate string) (string, error) {
 	if releaseDate == "" {
 		return "", nil
 	}
@@ -142,14 +142,14 @@ func ReleaseDateToReleaseYear(releaseDate string) (string, error) {
 	return dateSplit[0], nil
 }
 
-func PosterPathToPosterUrl(posterPath string) string {
+func posterPathToPosterUrl(posterPath string) string {
 	if posterPath != "" {
 		return "https://image.tmdb.org/t/p/w500" + posterPath
 	}
 	return ""
 }
 
-func BackdropPathToBackdropUrl(backdropPath string) string {
+func backdropPathToBackdropUrl(backdropPath string) string {
 	if backdropPath != "" {
 		return "https://image.tmdb.org/t/p/original" + backdropPath
 	}


### PR DESCRIPTION
resolves #5

### what
Add bindings in backend for TMDB request by introducing the following backend endpoints:
- `/v1/tmdb/browse/movies/popular&page={PAGE}`
- `/v1/tmdb/search/movies?query={QUERY}&page={PAGE}`
- `/v1//tmdb/movies/{MOVIE_ID}`

Note: the `page` query parameter is optional here and defaults to 1

Refactor the frontend to use these endpoints instead of the TMDB ones.

### why
1. Minimizes the different services the frontend needs to talk to.
2. Provides the ability to do certain transformations on the TMDB data. (such as parse release year, send complete urls for images, etc)
3. Allows us to be able to set the TMDB api key in the backend config 